### PR TITLE
remove check for dashboard option because dashboard is not an option anymore

### DIFF
--- a/pynetworktables2js/__main__.py
+++ b/pynetworktables2js/__main__.py
@@ -34,13 +34,13 @@ log_format = "%(asctime)s:%(msecs)03d %(levelname)-8s: %(name)-20s: %(message)s"
 
 def init_networktables(options):
 
-    if options.dashboard:
-        logger.info("Connecting to networktables in Dashboard mode")
-        NetworkTables.setDashboardMode()
-    else:
-        logger.info("Connecting to networktables at %s", options.robot)
-        NetworkTables.setIPAddress(options.robot)
-        NetworkTables.setClientMode()
+    #if options.dashboard:
+    #    logger.info("Connecting to networktables in Dashboard mode")
+    #    NetworkTables.setDashboardMode()
+    #else:
+    logger.info("Connecting to networktables at %s", options.robot)
+    NetworkTables.setIPAddress(options.robot)
+    NetworkTables.setClientMode()
     
     NetworkTables.setNetworkIdentity(options.identity)
     NetworkTables.initialize()


### PR DESCRIPTION
After upgrading to the new release of `pynetworktables2js`, I get the following error:

> File "c:\users\czhao\onedrive\documents\frc2017-1123\venv\lib\site-packages\pynetworktables2js\__main__.py", line 37, in init_networktables
    if options.dashboard:
AttributeError: 'Values' object has no attribute 'dashboard'

I think this'll fix it.