### PR TITLE
getNtCache()

### DIFF
--- a/pynetworktables2js/js/networktables.js
+++ b/pynetworktables2js/js/networktables.js
@@ -218,6 +218,13 @@ var NetworkTables = new function() {
         return robotAddress;
     };
 
+    /**
+     * @returns {*} an in-memory cache, which stores keys in a flat-object, instead of a tree
+     */
+    this.getNtCache = function() {
+        return ntCache;
+    };
+
     // returns true if robot is connected
     this.isRobotConnected = function() {
         return robotConnected;

--- a/pynetworktables2js/js/networktables.js
+++ b/pynetworktables2js/js/networktables.js
@@ -75,6 +75,7 @@ const NetworkTables = new function() {
      that indicates whether the websocket is connected
      :param immediateNotify: If true, the function will be immediately called
      with the current status of the websocket
+     :returns function to stop listening for connection events
      */
     this.addWsConnectionListener = function(f, immediateNotify = false) {
         connectionListeners.add(f);
@@ -95,6 +96,7 @@ const NetworkTables = new function() {
      that indicates whether the robot is connected
      :param immediateNotify: If true, the function will be immediately called
      with the current robot connection state
+     :returns function to stop listening for connection events
      */
     this.addRobotConnectionListener = function(f, immediateNotify = false) {
         robotConnectionListeners.add(f);
@@ -113,6 +115,7 @@ const NetworkTables = new function() {
      for entry, value: value of entry, isNew: If true, the entry has just been created
      :param immediateNotify: If true, the function will be immediately called
      with the current value of all keys
+     :returns function to stop listening for connection events
      */
     this.addGlobalListener = function(f, immediateNotify = false) {
         globalListeners.push(f);
@@ -134,6 +137,7 @@ const NetworkTables = new function() {
      for entry, value: value of entry, isNew: If true, the entry has just been created
      :param immediateNotify: If true, the function will be immediately called
      with the current value of the specified key
+     :returns function to stop listening for connection events
      */
     this.addKeyListener = function(key, f, immediateNotify = false) {
         const listeners = keyListeners.get(key);

--- a/pynetworktables2js/js/utils.js
+++ b/pynetworktables2js/js/utils.js
@@ -1,16 +1,16 @@
 "use strict";
 /**
-    The functions in this file are still experimental in nature, and as we
-    expand the number of functions in this file it is expected that the API
-    will change.
+ The functions in this file are still experimental in nature, and as we
+ expand the number of functions in this file it is expected that the API
+ will change.
 
-    Possible API additions in the future:
-    - attach button to boolean
-    - attach button to number
-    - attach button to boolean (toggle) -- auto update class when clicked
-    - attach chooser to list of buttons
-      -> needs a list of button ids
-*/
+ Possible API additions in the future:
+ - attach button to boolean
+ - attach button to number
+ - attach button to boolean (toggle) -- auto update class when clicked
+ - attach chooser to list of buttons
+ -> needs a list of button ids
+ */
 
 
 // requirements
@@ -23,20 +23,19 @@ if ($ === undefined) {
 }
 
 
-
 /**
-    Given the id of an HTML select element and the key name of a SendableChooser
-    object setup in networktables, this will sync the select combo box with the
-    contents of the SendableChooser, and you will be able to select an object
-    using the select element.
+ Given the id of an HTML select element and the key name of a SendableChooser
+ object setup in networktables, this will sync the select combo box with the
+ contents of the SendableChooser, and you will be able to select an object
+ using the select element.
 
-    :param html_id: An ID of an HTML select element
-    :param nt_key: The name of the NetworkTables key that the SendableChooser
-                   is associated with
+ :param html_id: An ID of an HTML select element
+ :param nt_key: The name of the NetworkTables key that the SendableChooser
+ is associated with
 
-    See the WPILib documentation for information on how to use SendableChooser
-    in your robot's program.
-*/
+ See the WPILib documentation for information on how to use SendableChooser
+ in your robot's program.
+ */
 function attachSelectToSendableChooser(html_id, nt_key) {
 
     if (!nt_key.startsWith('/')) {
@@ -50,25 +49,25 @@ function attachSelectToSendableChooser(html_id, nt_key) {
     NetworkTables.addKeyListener(nt_key + '/options', update, true);
     NetworkTables.addKeyListener(nt_key + '/default', update, true);
     NetworkTables.addKeyListener(nt_key + '/selected', update, true);
-    
+
     $(html_id).change(function() {
-      NetworkTables.putValue(nt_key + "/selected", $(html_id).val());
+        NetworkTables.putValue(nt_key + "/selected", $(html_id).val());
     });
 }
 
 
 /**
-    This function is designed to be used from the onValueChanged callback
-    whenever values from a SendableChooser change, but you probably should
-    prefer to use attachSelectToSendableChooser instead.
+ This function is designed to be used from the onValueChanged callback
+ whenever values from a SendableChooser change, but you probably should
+ prefer to use attachSelectToSendableChooser instead.
 
-    See attachSelectToSendableChooser documentation.
-*/
+ See attachSelectToSendableChooser documentation.
+ */
 function updateSelectWithChooser(html_id, nt_key) {
 
     var options = NetworkTables.getValue(nt_key + '/options');
     if (options === undefined)
-        return; 
+        return;
 
     var optDefault = NetworkTables.getValue(nt_key + '/default');
     var selected = NetworkTables.getValue(nt_key + '/selected');
@@ -80,7 +79,7 @@ function updateSelectWithChooser(html_id, nt_key) {
     opt.enter()
         .append("option");
 
-    opt.text(function(d,i){
+    opt.text(function(d, i) {
         return options[i];
     });
 
@@ -94,34 +93,34 @@ function updateSelectWithChooser(html_id, nt_key) {
 }
 
 /**
-    Creates a circle SVG that turns red when robot is not connected, green when
-    it is connected.
-    
-    :param html_id: ID to insert svg into
-    :param size: Size of circle
-    :param stroke_width: Border of circle
-*/
+ Creates a circle SVG that turns red when robot is not connected, green when
+ it is connected.
+
+ :param html_id: ID to insert svg into
+ :param size: Size of circle
+ :param stroke_width: Border of circle
+ */
 function attachRobotConnectionIndicator(html_id, size, stroke_width) {
     if (!size)
         size = 20;
-        
-    size = Math.round(size/2.0)*2;
-    
+
+    size = Math.round(size / 2.0) * 2;
+
     if (!stroke_width)
-        stroke_width = Math.ceil(size/10.0);
-    
-    var r = Math.round((size - stroke_width*2)/ 2);
-    
+        stroke_width = Math.ceil(size / 10.0);
+
+    var r = Math.round((size - stroke_width * 2) / 2);
+
     var svg = d3.select(html_id).append('svg')
-                                .attr('width', size)
-                                .attr('height', size);
+        .attr('width', size)
+        .attr('height', size);
     var circle = svg.append('circle')
-                    .attr('cx', r + stroke_width)
-                    .attr('cy', r + stroke_width)
-                    .attr('r', r)
-                    .style('stroke', 'black')
-                    .style('stroke-width', stroke_width);
-    
+        .attr('cx', r + stroke_width)
+        .attr('cy', r + stroke_width)
+        .attr('r', r)
+        .style('stroke', 'black')
+        .style('stroke-width', stroke_width);
+
     NetworkTables.addRobotConnectionListener(function(connected) {
         circle.style('fill', connected ? 'lime' : 'red');
     }, true);


### PR DESCRIPTION
Allows the client to get access to the flat in-memory cache of the values from NetworkTables, which will make it easier to implement features like sorting without creating another cache.