### PR TITLE
Added function to connect to another NetworkTables server client side

### DIFF
--- a/pynetworktables2js/js/networktables.js
+++ b/pynetworktables2js/js/networktables.js
@@ -679,6 +679,23 @@ const NetworkTables = new function () {
 		return true;
 	};
 
+	/**
+	 * Attempts to connect to another address.
+	 * 
+	 * :param address: The NetworkTable server address to connect to
+	 */
+	this.connect = function(address) {
+		if (!socketOpen)
+			return false;
+		
+		if (typeof address !== "string")
+			throw new Error("address should be type 'string");
+
+		ntCache = new Map();
+		socket.send(CBOR.encode({'a': address }));
+		return true;
+	}
+
 	// backwards compatibility; deprecated
 	this.setValue = this.putValue;
 	socketOpen = false;

--- a/pynetworktables2js/js/networktables.js
+++ b/pynetworktables2js/js/networktables.js
@@ -689,7 +689,7 @@ const NetworkTables = new function () {
 			return false;
 		
 		if (typeof address !== "string")
-			throw new Error("address should be type 'string");
+			throw new Error("address should be type 'string'");
 
 		ntCache = new Map();
 		socket.send(CBOR.encode({'a': address }));

--- a/pynetworktables2js/nt_serial.py
+++ b/pynetworktables2js/nt_serial.py
@@ -56,6 +56,5 @@ class NTSerial(object):
         """
         Clean up NetworkTables listeners
         """
-        print("close")
         NetworkTables.removeGlobalListener(self._nt_on_change)
         NetworkTables.removeConnectionListener(self._nt_connected)

--- a/pynetworktables2js/nt_serial.py
+++ b/pynetworktables2js/nt_serial.py
@@ -16,13 +16,19 @@ class NTSerial(object):
         formatted as strings.
         """
         self.update_callback = update_callback
-        NetworkTables.addGlobalListener(self._nt_on_change, immediateNotify=True)
-        NetworkTables.addConnectionListener(self._nt_connected, immediateNotify=True)
+        self.open()
 
     def process_update(self, update):
         """Process an incoming update from a remote NetworkTables"""
         data = cbor2.loads(update)
-        NetworkTables.getEntry(data["k"]).setValue(data["v"])
+        if "a" in data:
+            self.close()
+            self._nt_connected(False, None)
+            NetworkTables.shutdown()
+            NetworkTables.initialize(data["a"])
+            self.open()
+        else:
+            NetworkTables.getEntry(data["k"]).setValue(data["v"])
 
     def _send_update(self, data):
         """Send a NetworkTables update via the stored send_update callback"""
@@ -38,9 +44,18 @@ class NTSerial(object):
     def _nt_connected(self, connected, info):
         self._send_update({"r": connected, "a": NetworkTables.getRemoteAddress()})
 
+
+    def open(self):
+        """
+        Add NetworkTables listeners
+        """
+        NetworkTables.addGlobalListener(self._nt_on_change, immediateNotify=True)
+        NetworkTables.addConnectionListener(self._nt_connected, immediateNotify=True)
+
     def close(self):
         """
         Clean up NetworkTables listeners
         """
+        print("close")
         NetworkTables.removeGlobalListener(self._nt_on_change)
         NetworkTables.removeConnectionListener(self._nt_connected)


### PR DESCRIPTION
Added `NetworkTables.connect(address)` function, which attempts to connect to another server and flushes the ntCache. On the server a message is sent to the client that the robot connection was lost, the NetworkTables client is reinitialized with another address, and the listeners are recreated.