### PR TITLE
Allow cbor2 versions above 5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cbor2<5.0
+cbor2~=5.0
 tornado
 pynetworktables


### PR DESCRIPTION
This is a fix for #44

Turns out the underlying issue in 44 comes from the older cbor2 version 4.9, i tested on python 3.10 with cbor2 version 5.4.2 and it seemed to work fine but im not sure if this would break older python versions.